### PR TITLE
normalize之后_train_samples纬度会发生改变，不能直接用imshow

### DIFF
--- a/4-6/load.py
+++ b/4-6/load.py
@@ -108,6 +108,9 @@ if __name__ == '__main__':
 	pass
 	# inspect(_train_samples, _train_labels, 1234)
 	# _train_samples = normalize(_train_samples)
+	# normalize之后_train_samples维度会发生改变，直接用imshow会报错
+    	# 需要降维才能画出图
+    	# _train_samples = _train_samples[:,:,:,0]
 	# inspect(_train_samples, _train_labels, 1234)
 	# distribution(train_labels, 'Train Labels')
 	# distribution(test_labels, 'Test Labels')


### PR DESCRIPTION
python2.7情况下，normalize直接用inspect会报错，维度问题
normalize之前_train_samples的纬度(73257, 32, 32, 3)
之后纬度为(73257, 32, 32, 1)
将其转化为(73257, 32, 32)即可画出图
